### PR TITLE
Feature relationproxy select

### DIFF
--- a/source/dpq/connection.d
+++ b/source/dpq/connection.d
@@ -938,7 +938,7 @@ struct Connection
 		Params:
 			id = value of the relation's PK to filter by
 			updates = the structure that will provide values for the UPDATE
-			asnyc = whether the query should be sent async
+			async = whether the query should be sent async
 
 		Examples:
 		------------------

--- a/source/dpq/querybuilder.d
+++ b/source/dpq/querybuilder.d
@@ -459,9 +459,10 @@ struct QueryBuilder
 		assert(qb._offset == 1);
 	}
 
+	/// Row-level locking
 	ref QueryBuilder for_(RowLock lock)
 	{
-		assert(_type == QueryType.select, "QueryBuilder.for_() can only be used for SELECT queries.");
+		assert(_type == QueryType.select, "QueryBuilder.for_() can only be used on SELECT queries.");
 		_rowLock = lock;
 		return this;
 	}

--- a/source/dpq/relationproxy.d
+++ b/source/dpq/relationproxy.d
@@ -4,6 +4,7 @@ import dpq.attributes;
 import dpq.connection;
 import dpq.querybuilder;
 import dpq.value : Value;
+public import dpq.querybuilder : RowLock;
 
 import std.algorithm : map;
 import std.array;
@@ -266,6 +267,13 @@ struct RelationProxy(T)
 			return RT.init;
 		
 		return RT(result[result.rows - 1].deserialise!T);
+	}
+
+	@property ref auto for_(RowLock lock)
+	{
+		_markStale();
+		_queryBuilder.for_(lock);
+		return this;
 	}
 
 	/**

--- a/source/dpq/result.d
+++ b/source/dpq/result.d
@@ -211,7 +211,7 @@ struct Result
 	int currentRangeIndex = 0;
 	@property bool empty()
 	{
-		return currentRangeIndex >= this.rows - 1;
+		return currentRangeIndex >= this.rows;
 	}
 
 	void popFront()


### PR DESCRIPTION
Methods with LIMIT and row-level locking are added on RelationProxy.

I've implemented two additional methods for `first` and `last` to make them possible to use with any parameters, like `User.first(10)` or `User.first("data")` or `User.first(5, "id")` without forcing a user to specify `-1` for limit in the second case. It allows us to use limit, column to sort by, both or none of them as arguments. Currently `first` and `last` support only one column to be sorted on.

`fetch(-1)` and `all()` are completely equivalent, but I've defined a new `fetch` method considering `all()` implies returning, well, all matching rows and `all(2)` is something not so clear.

I've noticed that there supposed to be Order parameter for the `first` in the documentation, but I've not implemented it since `first(Order.desc)` is equivalent to `last()`, but looks too sophisticated, and visa versa.

Cached content will be reloaded from a database every time a result is sorted on a new field. It will send a new request to the DB engine as a database sort should be faster on average due to indexes. `last` methods use ascending sort too, but returns last members of result in reversed order. This allows us to avoid additional DB requests when using `last` and `first` multiple times not changing filters. Instead, it requires `last` to do additional work reversing result. I'm not sure which is generally better, additional request or reversing.

It also currently fetches (any of `all`/`fetch`/`first`/`last` methods) all results matching filters. This may be useful on small data sets, e.g. this code
```d
auto rp = RelationProxy!User(conn);
auto users = rp.first(10);
users = rp.last;
```
will not send the second query and will only use the cached data. But fetching all matching results might cause significant slowdown and memory waste on large data sets, e.g. if there were hundreds of thousands of users in the example above and we needed only a couple of them.