### PR TITLE
Fixed postgres crash on empty filter

### DIFF
--- a/source/dpq/connection.d
+++ b/source/dpq/connection.d
@@ -699,8 +699,9 @@ struct Connection
 	{
 		QueryBuilder qb;
 		qb.select(AttributeList!T)
-			.from(relationName!T)
-			.where(filter);
+			.from(relationName!T);
+		if (filter != "")
+			qb.where(filter);
 
 		auto q = qb.query(this);
 


### PR DESCRIPTION
Fixed a problematic issue with the new version of postgres, where they do not allow empty `WHERE` clause, which breaks every `find` command in dpq.