### PR TITLE
Fix #26: replace TickDuration with Duration

### DIFF
--- a/source/dpq/query.d
+++ b/source/dpq/query.d
@@ -199,7 +199,7 @@ struct Query
 	 */
 	Result run()
 	{
-		import std.datetime;
+		import std.datetime.stopwatch : StopWatch;
 
 		StopWatch sw;
 		sw.start();

--- a/source/dpq/result.d
+++ b/source/dpq/result.d
@@ -27,7 +27,7 @@ struct Result
 {
 	alias ResultPtr = SmartPointer!(PGresult*, PQclear);
 	private ResultPtr _result;
-	private TickDuration _time;
+	private Duration _time;
 
 	this(PGresult* res)
 	{
@@ -122,12 +122,12 @@ struct Result
 		c.exec("DROP TABLE test_query");
 	}
 
-	@property TickDuration time()
+	@property Duration time()
 	{
 		return _time;
 	}
 
-	@property package void time(TickDuration time)
+	@property package void time(Duration time)
 	{
 		_time = time;
 	}


### PR DESCRIPTION
See also [this warning](https://dlang.org/phobos/core_time.html#.TickDuration).