### PR TITLE
Fix compilation on D 2.097

### DIFF
--- a/source/dpq/connection.d
+++ b/source/dpq/connection.d
@@ -799,7 +799,7 @@ struct Connection
       int nUpdates = c.update!Test("n = $1", "n = $2", 5, 123);
       assert(nUpdates == 1, `nUpdates == 1`);
 
-      t = c.findOneBy!Test("n", 123);
+      t = c.findOneBy!Test("n", 123).get;
       assert(t.n == 123, `t.n == 123`);
 
       writeln("\t\t * async");
@@ -952,7 +952,7 @@ struct Connection
       t.n = 2;
       c.update!Test(1, t);
 
-      t = c.findOne!Test(1);
+      t = c.findOne!Test(1).get;
       assert(t.n == 2);
 
       t.n = 3;
@@ -1138,7 +1138,7 @@ struct Connection
 
       auto res = c.nextResult();
       assert(res.rows == 1);
-      t2 = c.findOneBy!Test("n", 123);
+      t2 = c.findOneBy!Test("n", 123).get;
       assert(t.n2.isNull);
       assert(t2.n2.isNull);
 

--- a/source/dpq/serialisation.d
+++ b/source/dpq/serialisation.d
@@ -36,9 +36,12 @@ package Nullable!(ubyte[]) toBytes(T)(T val)
 
    alias serialiser = SerialiserFor!AT;
 
-   auto av = (cast(AT)(val));
-   auto x = serialiser.serialise(av);
-   return Nullable!(ubyte[])(x.get);
+   static if (isInstanceOf!(Nullable, T))
+      auto av = val.get;
+   else
+      auto av = val;
+
+   return serialiser.serialise(cast(AT) av);
 }
 
 /*****************************************************************************/

--- a/source/dpq/serialisers/array.d
+++ b/source/dpq/serialisers/array.d
@@ -144,7 +144,7 @@ struct ArraySerialiser
 					else
 					{
 						result ~= nativeToBigEndian(cast(int) bs.get.length);
-						result ~= bs;
+						result ~= bs.get;
 					}
 				}
 			}

--- a/source/dpq/serialisers/composite.d
+++ b/source/dpq/serialisers/composite.d
@@ -86,7 +86,7 @@ struct CompositeTypeSerialiser
 			{
 				// The element length and data itself
 				data ~= nativeToBigEndian(bytes.get.length.to!int);
-				data ~= bytes;
+				data ~= bytes.get;
 			}
 		}
 

--- a/source/dpq/serialisers/scalar.d
+++ b/source/dpq/serialisers/scalar.d
@@ -21,7 +21,7 @@ struct ScalarSerialiser
 
 	static void enforceSupportedType(T)()
 	{
-		assert(
+		static assert(
 				isSupportedType!T,
 				"'%s' is not supported by ScalarSerialiser".format(T.stringof));
 	}
@@ -36,7 +36,8 @@ struct ScalarSerialiser
 		if (isAnyNull(val))
 			return RT.init;
 
-		return RT(nativeToBigEndian(val).dup);
+		auto bytes = nativeToBigEndian(val);
+		return RT(bytes.dup);
 	}
 
 	static T deserialise(T)(const(ubyte)[] bytes)

--- a/source/dpq/serialisers/systime.d
+++ b/source/dpq/serialisers/systime.d
@@ -43,7 +43,7 @@ struct SysTimeSerialiser
 
       import std.datetime.timezone : UTC;
 
-      return SysTime(fromBytes!long(bytes, long.sizeof) * 10 + SysTime(POSTGRES_EPOCH, UTC()).stdTime);
+      return SysTime(fromBytes!long(bytes, long.sizeof).get * 10 + SysTime(POSTGRES_EPOCH, UTC()).stdTime);
    }
 
    static Oid oidForType(T)()


### PR DESCRIPTION
dpq no longer compiles on D 2.097 due to this following change: https://dlang.org/changelog/2.097.0.html#nullable-remove-alias-get-this